### PR TITLE
chore: bump uv to 0.11.32 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 FROM python-base AS builder-base
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.25 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /bin/
 
 WORKDIR $WORKDIR_PATH
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 - [Python](https://www.python.org/downloads/) **>=3.14.0 <3.15.0** (_tested with 3.14.6_)
 - [pre-commit](https://pre-commit.com/#install) **>=3.2.0 <5.0.0** (_tested with 4.5.1_)
-- [uv](https://docs.astral.sh/uv/getting-started/installation/) **>=0.11.21** (_tested with 0.11.25_)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) **>=0.11.21** (_tested with 0.11.32_)
 - [docker](https://docs.docker.com/get-docker/) (_optional_)
 
 ---


### PR DESCRIPTION
## Summary

The `uv` binary copied into the Docker builder stage was still pinned to `0.11.25`, missed in #128. Bumped to `0.11.32` (current latest), and updated the matching "tested with" note in the README prerequisites.

## Notes

- `ghcr.io/astral-sh/uv:0.11.32` manifest verified to exist before pinning.
- The `>=0.11.21` floors in `pyproject.toml` (`build-system.requires` and `tool.uv.required-version`) are deliberately left alone — nothing here requires a newer minimum.
- CI resolves uv from `version-file: pyproject.toml`, so the workflow already ran on 0.11.32; only the Docker stage was stale.

## Verification

`pre-commit run --all-files` passes locally. The `build-image` CI job exercises the new pin.