### PR TITLE
docs: add ty logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <a href="https://github.com/astral-sh/uv" target="blank"><img src="https://github.com/astral-sh/uv/blob/8674968a17e5f2ee0dda01d17aaf609f162939ca/docs/assets/logo-letter.svg" height="100" alt="uv logo" /></a>
   <a href="https://pre-commit.com/" target="blank"><img src="https://pre-commit.com/logo.svg" height="100" alt="pre-commit logo" /></a>
   <a href="https://github.com/astral-sh/ruff" target="blank"><img src="https://raw.githubusercontent.com/astral-sh/ruff/8c20f14e62ddaf7b6d62674f300f5d19cbdc5acb/docs/assets/bolt.svg" height="100" alt="ruff logo" style="background-color: #ef5552" /></a>
+  <a href="https://github.com/astral-sh/ty" target="blank"><img src="https://raw.githubusercontent.com/astral-sh/ty/fba03297fe52271bf413c3cd1ea896976e57e19e/docs/assets/logo-letter.svg" height="100" alt="ty logo" /></a>
   <a href="https://docs.pytest.org/" target="blank"><img src="https://raw.githubusercontent.com/pytest-dev/pytest/main/doc/en/img/pytest_logo_curves.svg" height="100" alt="pytest logo" /></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Add the ty logo (astral-sh/ty docs/assets/logo-letter.svg) to the header icon row, alongside uv, ruff & pytest

## Test plan
- [ ] CI green